### PR TITLE
Feature elevated queue

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=150

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -11,6 +11,9 @@ Roles:
   Admin:
     Name: !ENV ${ADMIN_NAME}
     RoleID: !ENV ${ADMIN_ROLE_ID}
+  Instructor:
+    Name: !ENV ${INSTRUCTOR_NAME}
+    RoleID: !ENV ${INSTRUCTOR_ROLE_ID}
   Student:
     Name: !ENV ${STUDENT_NAME}
     RoleID: !ENV ${STUDENT_ROLE_ID}

--- a/configs/help_messages.yaml
+++ b/configs/help_messages.yaml
@@ -15,6 +15,8 @@ aliases:
       '
 
   - &queuehelp_admin '
+      *Enqueue
+
       *Clear the OH queue by using the following command:*
 
       `/clear or /cq`

--- a/configs/help_messages.yaml
+++ b/configs/help_messages.yaml
@@ -15,7 +15,12 @@ aliases:
       '
 
   - &queuehelp_admin '
-      *Enqueue
+      *Enqueue a particular student into an instructor''s elevated queue:*
+
+      `/eq @student @target_instructor`
+
+      ------------
+
 
       *Clear the OH queue by using the following command:*
 

--- a/generateEnv.py
+++ b/generateEnv.py
@@ -43,6 +43,8 @@ def main(token:str) -> int:
                 "ADMIN_ROLE_ID" : find(lambda role : role.name == "Admin", client.guilds[0].roles).id,
                 "STUDENT_NAME": "Student",
                 "STUDENT_ROLE_ID" : find(lambda role : role.name == "Student", client.guilds[0].roles).id,
+                "INSTRUCTOR_NAME": "Instructor",
+                "INSTRUCTOR_ROLE_ID": find(lambda role : role.name == "Instructor", client.guilds[0].roles).id
             }
 
             print(f"Variables Gathered, Writing...")

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -14,7 +14,7 @@ runShellCheck(){
 runPythonLinter(){
     
     for file in $(find src -iname '*.py'); do
-        if ! flake8 --max-line-length=150 "$file"; then
+        if ! flake8 "$file"; then
             EXIT_CODE=2
         fi 
     done

--- a/src/cogs/help.py
+++ b/src/cogs/help.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 from discord.ext.commands import Context
 from yaml import load, add_constructor
 
-from user_utils import isAdmin
+from user_utils import isAdmin, isAtLeastInstructor
 from cogs.tools import selfClean
 from constants import GetConstants
 from errors import CommandPermissionError
@@ -30,8 +30,8 @@ class Help(commands.Cog):
     @commands.group(name='help', invoke_without_command=True)
     async def help_cmd(self, ctx: Context) -> None:
         try:
-            await isAdmin(ctx)
-            logger.debug(f"{ctx.author} requested to see all admin commands")
+            await isAtLeastInstructor(ctx)
+            logger.debug(f"{ctx.author} requested to see all instructor commands")
             help_string = self.help_messages['all_admin']
         except CommandPermissionError:
             logger.debug(f"{ctx.author} requested to see all student commands")
@@ -42,8 +42,8 @@ class Help(commands.Cog):
     @help_cmd.command(name='queue')
     async def queue_help(self, ctx: Context) -> None:
         try:
-            await isAdmin(ctx)
-            logger.debug(f"{ctx.author} requested to see admin commands for the queue")
+            await isAtLeastInstructor(ctx)
+            logger.debug(f"{ctx.author} requested to see instructor commands for the queue")
             help_string = self.help_messages['queue_admin']
         except CommandPermissionError:
             logger.debug(f"{ctx.author} requested to see student commands for the queue")

--- a/src/cogs/oh_queue.py
+++ b/src/cogs/oh_queue.py
@@ -114,8 +114,9 @@ class OH_Queue(commands.Cog):
                 raise OHQueueCommandUseError
 
         except OHQueueCommandUseError:
-            logger.error("")
-            await context.author.send("You ")
+            logger.error(f"User: {context.author} tried to use eq with the "
+                         f"following command: /eq {student} {instructor}")
+            await context.author.send("You did not use the eq command correctly")
 
     async def _eq_default(self, context: Context):
         sender = context.author

--- a/src/cogs/oh_queue.py
+++ b/src/cogs/oh_queue.py
@@ -14,7 +14,7 @@ from tabulate import tabulate
 
 from user_utils import isAdmin, userToMember, isStudent
 from cogs.oh_state_manager import OHState, officeHoursAreOpen
-from errors import CommandPermissionError, OHQueueCommandUseError
+from errors import OHQueueCommandUseError
 
 from constants import GetConstants
 
@@ -257,7 +257,6 @@ class OH_Queue(commands.Cog):
             # Add this student to the voice chat
             await student.move_to(sender.voice.channel)
             logger.debug(f"{student} has been summoned and moved to {sender.voice.channel}")
-
 
     @commands.command(aliases=["cq", "clearqueue"])
     @commands.check(isAdmin)

--- a/src/cogs/oh_queue.py
+++ b/src/cogs/oh_queue.py
@@ -9,14 +9,12 @@ from discord.ext import commands
 from discord.ext.commands import Bot, MemberConverter
 from discord.ext.commands.context import Context
 from discord.ext.commands.errors import BadArgument
-
 from tabulate import tabulate
 
-from user_utils import isAdmin, userToMember, isStudent
 from cogs.oh_state_manager import OHState, officeHoursAreOpen
-from errors import OHQueueCommandUseError
-
 from constants import GetConstants
+from errors import OHQueueCommandUseError
+from user_utils import userToMember, isStudent, isAtLeastInstructor
 
 logger = getLogger(f"main.{__name__}")
 
@@ -109,7 +107,7 @@ class OH_Queue(commands.Cog):
                 await self._eq_default(context)
 
             # Case where the two optional arguments have been passed in
-            elif student and instructor and await isAdmin(context):
+            elif student and instructor and await isAtLeastInstructor(context):
                 await self._eq_elevated_queue(context, student, instructor)
             # Else the command was not used properly
             else:
@@ -259,7 +257,7 @@ class OH_Queue(commands.Cog):
             logger.debug(f"{student} has been summoned and moved to {sender.voice.channel}")
 
     @commands.command(aliases=["cq", "clearqueue"])
-    @commands.check(isAdmin)
+    @commands.check(isAtLeastInstructor)
     async def clearQueue(self, context: Context):
         """
         Clears all students from the queue

--- a/src/cogs/oh_queue.py
+++ b/src/cogs/oh_queue.py
@@ -8,12 +8,13 @@ from discord import TextChannel, VoiceChannel, Invite, User, Permissions, Member
 from discord.ext import commands
 from discord.ext.commands import Bot, MemberConverter
 from discord.ext.commands.context import Context
+from discord.ext.commands.errors import BadArgument
 
 from tabulate import tabulate
 
 from user_utils import isAdmin, userToMember
 from cogs.oh_state_manager import OHState, officeHoursAreOpen
-from errors import CommandPermissionError
+from errors import CommandPermissionError, OHQueueCommandUseError
 
 from constants import GetConstants
 
@@ -27,7 +28,7 @@ class OH_Queue(commands.Cog):
         self.OHQueue: List[Member] = list()
         self.admins = list()
 
-        self.instructor_queue = defaultdict(SimpleQueue)
+        self.instructor_queue: defaultdict[str, SimpleQueue] = defaultdict(SimpleQueue)
 
         # Channel references are resolved by the pre invoke hook
         self.queue_channel: Optional[TextChannel] = None
@@ -65,7 +66,7 @@ class OH_Queue(commands.Cog):
         table_data = ((position + 1, user.nick if user.nick is not None else user.name) for (position, user)
                       in enumerate(self.OHQueue))
         table_text = tabulate(table_data, ["Position", "Name"], tablefmt="fancy_grid")
-        queue_text = f"The queue is currently {status}. "\
+        queue_text = f"The queue is currently {status}. " \
                      f"There are {len(self.OHQueue)} student(s) in the queue\n```{table_text}```"
 
         # Find any previous message sent by the bot in the queue channel
@@ -96,25 +97,27 @@ class OH_Queue(commands.Cog):
 
     @commands.command(aliases=["enterqueue", "eq"])
     @commands.check(officeHoursAreOpen)
-    async def enterQueue(self, context: Context, student: str=None, target_instructor: str=None):
+    async def enterQueue(self, context: Context, student: str = None, instructor: str = None):
         """
         Enters user into the OH queue
         if they already are enqueued return them their position in queue
         @ctx: context object containing information about the caller
         """
-        if not student and not target_instructor:
-            await self._eq_default(context)
-        elif student and target_instructor:
-            member_conv = MemberConverter()
+        try:
+            # Case of the normal eq use where the student enqueues themself
+            if not student and not instructor:
+                await self._eq_default(context)
 
-            student_id, instructor_id = await gather(member_conv.convert(context, student),
-                                                     member_conv.convert(context, target_instructor))
-            print(student_id)
-            print(instructor_id)
-        else:
+            # Case where the two optional arguments have been passed in
+            elif student and instructor and await isAdmin(context):
+                await self._eq_elevated_queue(context, student, instructor)
+            # Else the command was not used properly
+            else:
+                raise OHQueueCommandUseError
 
-
-
+        except OHQueueCommandUseError:
+            logger.error("")
+            await context.author.send("You ")
 
     async def _eq_default(self, context: Context):
         sender = context.author
@@ -159,6 +162,26 @@ class OH_Queue(commands.Cog):
                 delete_after=GetConstants().MESSAGE_LIFE_TIME
             )
 
+    async def _eq_elevated_queue(self, context: Context, student: str, instructor: str):
+        """
+        Manages the placing of a student into an instructor's elevated queue
+        :param context: Object containing information about the caller
+        :param student: The student that is being sent into another instructor's queue
+        :param instructor: The instructor that the student is being sent to
+        :return: None
+        """
+
+        member_conv = MemberConverter()
+        try:
+            student_id, instructor_id = await gather(member_conv.convert(context, student),
+                                                     member_conv.convert(context, instructor))
+            self.instructor_queue[instructor_id].put(student_id)
+            print(self.instructor_queue)
+            logger.debug(f"{context.author} has placed {student_id} into {instructor_id}'s queue")
+        except BadArgument:
+            logger.error(f"{context.author} gave the incorrect arguments"
+                         f" for the eq command: {student} and {instructor}")
+            await context.author.send("One of the users you entered is not a valid user")
 
     @commands.command(aliases=['leavequeue', 'lq'])
     async def leaveQueue(self, context: Context):
@@ -203,30 +226,36 @@ class OH_Queue(commands.Cog):
             await sender.send(
                 "You must be connected to a voice channel to do this. The queue has not been modified.")
 
+        elif self.instructor_queue[sender]:
+            student = self.instructor_queue[sender]
+            logger.debug(f"{context.author} dequeud {student} from their personal queue")
+            await self._dequeue_helper(context, student)
+
         elif len(self.OHQueue):
             student = self.OHQueue.pop(0)
             logger.debug(f"{student} has been dequeued")
-            if student.voice is None:
-                logger.debug(f"{student} was not in the waiting when they were dequeued")
-                await sender.send(
-                    f"{student.mention} is not in the waiting room or any of the breakout rooms. I cannot "
-                    "move them into your voice channel. They have been removed from the queue.",
-                    delete_after=GetConstants().MESSAGE_LIFE_TIME)
-                # This one should not get a message timeout. The user may be afk
-                await student.send(
-                    f"{student.mention} you have been called on but were not in the waiting room or any of the breakout"
-                    "rooms. I cannot move you into the office hours. You have been removed from the queue.",
-                    )
-            else:
-                await student.send(f"You are being summoned to {sender.mention}'s OH",
-                                   delete_after=GetConstants().MESSAGE_LIFE_TIME)
-                # Add this student to the voice chat
-                await student.move_to(sender.voice.channel)
-                logger.debug(f"{student} has been summoned and moved to {sender.voice.channel}")
+            await self._dequeue_helper(context, student)
+
+    async def _dequeue_helper(self, context: Context, student):
+        sender = context.author
+        if student.voice is None:
+            logger.debug(f"{student} was not in the waiting when they were dequeued")
+            await sender.send(
+                f"{student.mention} is not in the waiting room or any of the breakout rooms. I cannot "
+                "move them into your voice channel. They have been removed from the queue.",
+                delete_after=GetConstants().MESSAGE_LIFE_TIME)
+            # This one should not get a message timeout. The user may be afk
+            await student.send(
+                f"{student.mention} you have been called on but were not in the waiting room or any of the breakout"
+                "rooms. I cannot move you into the office hours. You have been removed from the queue.",
+            )
         else:
-            logger.debug(f"{sender} tried to dequeue from an empty queue")
-            await sender.send("The queue is empty. Perhaps now is a good time for a coffee break?",
-                              delete_after=GetConstants().MESSAGE_LIFE_TIME)
+            await student.send(f"You are being summoned to {sender.mention}'s OH",
+                               delete_after=GetConstants().MESSAGE_LIFE_TIME)
+            # Add this student to the voice chat
+            await student.move_to(sender.voice.channel)
+            logger.debug(f"{student} has been summoned and moved to {sender.voice.channel}")
+
 
     @commands.command(aliases=["cq", "clearqueue"])
     @commands.check(isAdmin)

--- a/src/cogs/oh_state_manager.py
+++ b/src/cogs/oh_state_manager.py
@@ -3,6 +3,7 @@ Cog to manage opening / closing office hours
 """
 from asyncio import gather
 from enum import Enum
+from logging import getLogger
 from typing import List
 
 from discord import TextChannel, Message
@@ -12,6 +13,8 @@ from discord.ext.commands import Cog, Bot, Context
 from constants import GetConstants
 from errors import OHStateError
 from user_utils import isAtLeastInstructor
+
+logger = getLogger(f"main.{__name__}")
 
 
 class OHState(Enum):
@@ -62,6 +65,7 @@ class OHStateManager(Cog):
                          "@here, the queue is now open."),
                      context.bot.get_cog("OH_Queue").onQueueUpdate()
                      )
+        logger.debug(f"{context.author} has opened the queue")
 
     @commands.command(aliases=["close", "end"])
     @commands.check(officeHoursAreOpen)
@@ -78,6 +82,7 @@ class OHStateManager(Cog):
                          "@here, the queue is now closed."),
                      context.bot.get_cog("OH_Queue").onQueueUpdate()
                      )
+        logger.debug(f"{context.author} has closed the queue")
 
 
 def setup(bot: Bot):

--- a/src/cogs/oh_state_manager.py
+++ b/src/cogs/oh_state_manager.py
@@ -5,13 +5,13 @@ from asyncio import gather
 from enum import Enum
 from typing import List
 
-from discord.ext.commands import Cog, Bot, Context
-from discord.ext import commands
 from discord import TextChannel, Message
+from discord.ext import commands
+from discord.ext.commands import Cog, Bot, Context
 
-from user_utils import isAdmin
-from errors import OHStateError
 from constants import GetConstants
+from errors import OHStateError
+from user_utils import isAtLeastInstructor
 
 
 class OHState(Enum):
@@ -48,7 +48,7 @@ class OHStateManager(Cog):
 
     @commands.command(aliases=["open", "start"])
     @commands.check(officeHoursAreClosed)
-    @commands.check(isAdmin)
+    @commands.check(isAtLeastInstructor)
     async def startOH(self, context: Context):
         self.state = OHState.OPEN
         # Send a message to the user and delete any and all messages made by the bot to the announcements channel
@@ -65,7 +65,7 @@ class OHStateManager(Cog):
 
     @commands.command(aliases=["close", "end"])
     @commands.check(officeHoursAreOpen)
-    @commands.check(isAdmin)
+    @commands.check(isAtLeastInstructor)
     async def stopOH(self, context: Context):
         self.state = OHState.CLOSED
         # Send a message to the user and delete any and all messages made by the bot to the announcements channel

--- a/src/cogs/oh_state_manager.py
+++ b/src/cogs/oh_state_manager.py
@@ -13,6 +13,7 @@ from discord.ext.commands import Cog, Bot, Context
 from constants import GetConstants
 from errors import OHStateError
 from user_utils import isAtLeastInstructor
+from cogs.tools import selfClean
 
 logger = getLogger(f"main.{__name__}")
 
@@ -59,9 +60,11 @@ class OHStateManager(Cog):
                      self.__remove_bot_messages(context)
                      )
 
+        if context.channel != GetConstants().QUEUE_CHANNEL_ID:
+            await selfClean(context)
+
         # Then remove the command message, send the announcement and trigger the queue message to reprint
-        await gather(
-                     (await context.bot.fetch_channel(GetConstants().ANNOUNCEMENT_CHANNEL_ID)).send(
+        await gather((await context.bot.fetch_channel(GetConstants().ANNOUNCEMENT_CHANNEL_ID)).send(
                          "@here, the queue is now open."),
                      context.bot.get_cog("OH_Queue").onQueueUpdate()
                      )
@@ -76,9 +79,12 @@ class OHStateManager(Cog):
         await gather(context.author.send("Office hours have been closed. No new students will be added to the queue."),
                      self.__remove_bot_messages(context)
                      )
+
+        if context.channel != GetConstants().QUEUE_CHANNEL_ID:
+            await selfClean(context)
+
         # Then remove the command message, send the announcement and trigger the queue message to reprint
-        await gather(
-                     (await context.bot.fetch_channel(GetConstants().ANNOUNCEMENT_CHANNEL_ID)).send(
+        await gather((await context.bot.fetch_channel(GetConstants().ANNOUNCEMENT_CHANNEL_ID)).send(
                          "@here, the queue is now closed."),
                      context.bot.get_cog("OH_Queue").onQueueUpdate()
                      )

--- a/src/cogs/voice.py
+++ b/src/cogs/voice.py
@@ -16,7 +16,7 @@ class voice(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.Cog.listener()
+    # @commands.Cog.listener()
     async def on_voice_state_update(self, member, before, after):
         conn = sqlite3.connect('voice.db')
         c = conn.cursor()

--- a/src/constants.py
+++ b/src/constants.py
@@ -92,7 +92,10 @@ class Constants:
 
         # Roles
         admin = config["Roles"]["Admin"]
-        self.ADMIN, self.INSTRUCTOR_ROLE_ID = admin["Name"], int(admin["RoleID"])
+        self.ADMIN, self.ADMIN_ROLE_ID = admin["Name"], int(admin["RoleID"])
+
+        instructor = config["Roles"]["Instructor"]
+        self.INSTRUCTOR, self.INSTRUCTOR_ROLE_ID = instructor["Name"], int(instructor["RoleID"])
 
         student = config["Roles"]["Student"]
         self.STUDENT, self.STUDENT_ROLE_ID = student["Name"], int(student["RoleID"])

--- a/src/errors.py
+++ b/src/errors.py
@@ -17,3 +17,10 @@ class OHStateError(CommandError):
     Raised when the expected OH state for a command is different from the actual state
     """
     pass
+
+
+class OHQueueCommandUseError(CommandError):
+    """
+    Raised when a user incorrectly uses the queue
+    """
+    pass

--- a/src/errors.py
+++ b/src/errors.py
@@ -17,3 +17,9 @@ class OHStateError(CommandError):
     Raised when the expected OH state for a command is different from the actual state
     """
     pass
+
+
+class OHQueueCommandUseError(CommandError):
+    """
+    Raised when a user incorrectly uses the queue
+    """

--- a/src/errors.py
+++ b/src/errors.py
@@ -23,3 +23,4 @@ class OHQueueCommandUseError(CommandError):
     """
     Raised when a user incorrectly uses the queue
     """
+    pass

--- a/src/errors.py
+++ b/src/errors.py
@@ -17,10 +17,3 @@ class OHStateError(CommandError):
     Raised when the expected OH state for a command is different from the actual state
     """
     pass
-
-
-class OHQueueCommandUseError(CommandError):
-    """
-    Raised when a user incorrectly uses the queue
-    """
-    pass

--- a/src/user_utils.py
+++ b/src/user_utils.py
@@ -29,9 +29,10 @@ async def userToMember(user: User, bot: commands.Bot) -> Optional[Member]:
     return member
 
 
-async def membership_check(context: commands.Context, role_id: str, role_name: str) -> bool:
+async def membership_check(context: commands.Context, role_id: str, role_name: str, throw_exception: bool = True) -> bool:
     """
     Checks if the author of the message in question belongs to the parameterized role
+    :param throw_exception: If true, will throw exception if user is not a member of the specified role
     :param context: Object containing metadata about the most recent message sent
     :param role_id: The UUID of the role for which we are checking for membership in
     :param role_name: The human-readable name of the role for which we are checking for membership in
@@ -50,7 +51,10 @@ async def membership_check(context: commands.Context, role_id: str, role_name: s
         roles = context.author.roles
 
     if not any(role.id == role_id for role in roles):
-        raise CommandPermissionError(f"User is not an {role_name}")
+        if throw_exception:
+            raise CommandPermissionError(f"User is not an {role_name}")
+        else:
+            return False
     return True
 
 
@@ -83,4 +87,4 @@ async def isStudent(context: commands.Context) -> bool:
     """
     Returns true if context.author has the Student role, false otherwise
     """
-    return await membership_check(context, GetConstants().STUDENT_ROLE_ID, GetConstants().STUDENT)
+    return await membership_check(context, GetConstants().STUDENT_ROLE_ID, GetConstants().STUDENT, throw_exception=False)

--- a/src/user_utils.py
+++ b/src/user_utils.py
@@ -70,6 +70,15 @@ async def isInstructor(context: commands.Context) -> bool:
     return await membership_check(context, GetConstants().INSTRUCTOR_ROLE_ID, GetConstants().INSTRUCTOR)
 
 
+async def isAtLeastInstructor(context: commands.Context) -> bool:
+    """
+    Returns true if context.author is either an admin or an instructor and False otherwise
+    :param context:
+    :return:
+    """
+    return await isInstructor(context) or await isAdmin(context)
+
+
 async def isStudent(context: commands.Context) -> bool:
     """
     Returns true if context.author has the Student role, false otherwise


### PR DESCRIPTION
- Added the Elevated Queue Functionality 
    - Added in a feature that allows instructors and admins to enqueue a specific student into an elevated queue of a particular instructor such that when the the target instructor dequeues their next student, it will first check to see if their elevated queue is empty. If it's not dequeue that student, else draw from the normal queue
    - The help messages were updated to reflect this change
- Reworked Permission Checks
    - Reworked configs to differentiate between Admins, Instructors, and Students
    - This means that permission check functions were generalized and a new function: `AtLeastInstructor` was added to check if the sender was either an admin or an instructor
    - The config file was modified to reflect this change
    - The setup script was updated to grab admin, instructor, and student role_id's all separately.
- Added a few logging statements to `oh_state_manager.py` since I noticed that we currently do no log that someone opened or closed OH
- Added a .flake8 file to configure the linter
    - The hook associated with this linter was updated as well