### PR TITLE
Dq improvement

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style = pep8
+column_limit = 150

--- a/configs/help_messages.yaml
+++ b/configs/help_messages.yaml
@@ -29,11 +29,24 @@ aliases:
       ------------
 
 
+      *Removes a particular student from both the common queue and any elevated queues:*
+
+      `/cq @student`
+
+      ------------
+
+
       *Call a student into your OH session by using the following command:*
 
       `/dequeue or /dq`
 
       ------------
+
+
+      *Summon a specific student to your OH room:*
+
+      `/dq @student`
+
       '
 
   - &voicehelp '

--- a/src/cogs/oh_queue.py
+++ b/src/cogs/oh_queue.py
@@ -240,15 +240,18 @@ class OH_Queue(commands.Cog):
     async def _dequeue_helper(self, context: Context, student):
         sender = context.author
         if student.voice is None:
-            logger.debug(f"{student} was not in the waiting when they were dequeued")
+            self.instructor_queue[sender].put(student)
+            logger.debug(f"{student} was not in the waiting when they were dequeued; they were placed in"
+                         f"{sender}'s elevated queue")
             await sender.send(
                 f"{student.mention} is not in the waiting room or any of the breakout rooms. I cannot "
-                "move them into your voice channel. They have been removed from the queue.",
+                "move them into your voice channel. They have been placed in your elevated queue. If they do"
+                "not show up, use /skip to remove them.",
                 delete_after=GetConstants().MESSAGE_LIFE_TIME)
             # This one should not get a message timeout. The user may be afk
             await student.send(
                 f"{student.mention} you have been called on but were not in the waiting room or any of the breakout"
-                "rooms. I cannot move you into the office hours. You have been removed from the queue.",
+                f"rooms. I cannot move you into the office hours. I will be dequeued by {sender} next.",
             )
         else:
             await student.send(f"You are being summoned to {sender.mention}'s OH",


### PR DESCRIPTION
- dq now doesn't remove students from queue. Instead that student will be placed into the elevated queue of the caller
- To prevent the situation of a non-responsive student being continuously placed in queue, per the previous, the cq command has been extended such that instructors can now remove students by name, i.e. `/cq @student`
- Instructors can now dq particular students like `/dq @student`. This can be helpful if dealing with multiple students.
- Help messages have been updated to reflect the above changes.
- Added my config file I use for yapf