### PR TITLE
Remove command

### DIFF
--- a/configs/help_messages.yaml
+++ b/configs/help_messages.yaml
@@ -15,6 +15,20 @@ aliases:
       '
 
   - &queuehelp_admin '
+      *Open the common OH queue and notify students*
+
+      `/open or /start`
+
+      ------------
+
+
+      *Close the common OH queue and notify students*
+
+      `/close or /end`
+
+      ------------
+
+
       *Enqueue a particular student into an instructor''s elevated queue:*
 
       `/eq @student @target_instructor`

--- a/configs/help_messages.yaml
+++ b/configs/help_messages.yaml
@@ -38,14 +38,14 @@ aliases:
 
       *Clear the OH queue by using the following command:*
 
-      `/clear or /cq`
+      `/clearqueue or /cq`
 
       ------------
 
 
       *Removes a particular student from both the common queue and any elevated queues:*
 
-      `/cq @student`
+      `/remove @student`
 
       ------------
 

--- a/configs/help_messages.yaml
+++ b/configs/help_messages.yaml
@@ -38,7 +38,7 @@ aliases:
 
       *Clear the OH queue by using the following command:*
 
-      `/clearqueue or /cq`
+      `/clear_queue`
 
       ------------
 

--- a/src/cogs/oh_queue.py
+++ b/src/cogs/oh_queue.py
@@ -279,7 +279,7 @@ class OH_Queue(commands.Cog):
             await student.move_to(sender.voice.channel)
             logger.debug(f"{student} has been summoned and moved to {sender.voice.channel}")
 
-    @commands.command(aliases=["cq", "clearqueue"])
+    @commands.command(aliases=["clear_queue"])
     @commands.check(isAtLeastInstructor)
     async def clearQueue(self, context: Context):
         """

--- a/src/cogs/oh_queue.py
+++ b/src/cogs/oh_queue.py
@@ -281,27 +281,44 @@ class OH_Queue(commands.Cog):
 
     @commands.command(aliases=["cq", "clearqueue"])
     @commands.check(isAtLeastInstructor)
-    async def clearQueue(self, context: Context, student: str = None):
+    async def clearQueue(self, context: Context):
         """
         Clears all students from the queue
         @ctx: context object containing information about the caller
         """
         sender = context.author
+        self.OHQueue.clear()
+        logger.debug(f"{sender} has cleared the queue")
+        await sender.send("The queue has been cleared.")
 
-        if student:
+    @commands.command(aliases=["remove", "rm"])
+    @commands.check(isAtLeastInstructor)
+    async def removeStudentFromQueue(self, context: Context, student: str = None):
+        """
+        Removes a student from any and all queues they are on.
+        @context: context object containing information about the caller
+        @student: String uniquely identifying a student
+        """
+        sender = context.author
+
+        if student is None:
+            logger.debug(f"{sender} used the remove command without specifying a student")
+            await sender.send(f"You must specify a student to remove. For example `/remove {sender}`")
+        else:
             member_conv = MemberConverter()
-            student = await member_conv.convert(context, student)
+            try:
+                student = await member_conv.convert(context, student)
+            except BadArgument as err:
+                logger.debug(f"{sender} called remove but student {student} could not be found.")
+                await sender.send(f"Student `{student}` not found.")
+                return
             if student in self.OHQueue:
                 self.OHQueue.remove(student)
             self._instructor_queue_find_and_remove(student)
 
             logger.debug(f"{sender} has removed {student} from all queues")
             await sender.send(f"You have removed {student} from all queues")
-        else:
-            self.OHQueue.clear()
 
-            logger.debug(f"{sender} has cleared the queue")
-            await sender.send("The queue has been cleared.")
 
     def _instructor_queue_find_and_remove(self, student: Member):
         for instructor, queue in self.instructor_queue.items():


### PR DESCRIPTION
This PR adds help messages for the open and close commands and renames the "/cq student" command to "/remove student". The latter was done to avoid accidental wiping of OH queue by accidentally entering "/cq" before specifying a student.